### PR TITLE
Prevent the component props to be resetted when unchanged

### DIFF
--- a/src/InjectedComponents.svelte
+++ b/src/InjectedComponents.svelte
@@ -7,7 +7,7 @@
 {#each $components as component (component.index)}
 	{#if component && component.toRender}
 		<Portal target={component.domElement} onChildMount={() => component.onMount()}>
-			<InjectedComponent {component} />
+			<InjectedComponent {component} props={component.props} />
 		</Portal>
 	{/if}
 {/each}

--- a/src/SvelteInjector.ts
+++ b/src/SvelteInjector.ts
@@ -298,7 +298,7 @@ export class SvelteInjector {
 		return new Promise((resolve) => {
 			components.update((components) => {
 				const index = components.indexOf(component);
-				components[index] = {...component};
+				components[index] = component;
 				// window["svelteElements"] = components;
 				resolve(undefined);
 				return components;

--- a/src/SvelteInjector.ts
+++ b/src/SvelteInjector.ts
@@ -298,7 +298,7 @@ export class SvelteInjector {
 		return new Promise((resolve) => {
 			components.update((components) => {
 				const index = components.indexOf(component);
-				components[index] = component;
+				components[index] = {...component};
 				// window["svelteElements"] = components;
 				resolve(undefined);
 				return components;

--- a/src/internal/InjectedComponent.svelte
+++ b/src/internal/InjectedComponent.svelte
@@ -1,9 +1,9 @@
-<!-- Prevent the component props being resetted when another component as been linked into InjectedComponents -->
 <!-- component.props should be considered immutable and to update the component props user has to update the instance -->
 <svelte:options immutable={true} />
 
 <script>
-    export let component;
+	export let component;
+	export let props;
 </script>
 
-<svelte:component this={component.Component} bind:this={component.instance} {...component.props} />
+<svelte:component this={component.Component} bind:this={component.instance} {...props} />

--- a/src/internal/InjectedComponent.svelte
+++ b/src/internal/InjectedComponent.svelte
@@ -1,3 +1,7 @@
+<!-- Prevent the component props being resetted when another component as been linked into InjectedComponents -->
+<!-- component.props should be considered immutable and to update the component props user has to update the instance -->
+<svelte:options immutable={true} />
+
 <script>
     export let component;
 </script>


### PR DESCRIPTION
Prevent the component props to be resetted when unchanged and the {#each} statement runs in InjectedComponents.svelte due to a foreign component being inserted/updated/removed.